### PR TITLE
Update dependencies and small fixes for mac m owners. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,48 @@
-FROM ubuntu:22.04
+# use this line for mac M1/M2
+FROM --platform=linux/x86_64 ubuntu:22.04
+
+# or use default ubuntu
+# FROM ubuntu:22.04
 
 LABEL MAINTAINER="Robin Genz <mail@robingenz.dev>"
 
 ARG JAVA_VERSION=17
 ARG NODEJS_VERSION=20
 # See https://developer.android.com/studio/index.html#command-tools
-ARG ANDROID_SDK_VERSION=9477386
+ARG ANDROID_SDK_VERSION=11076708
+# 9477386
 # See https://developer.android.com/tools/releases/build-tools
-ARG ANDROID_BUILD_TOOLS_VERSION=33.0.0
+ARG ANDROID_BUILD_TOOLS_VERSION=34.0.0 
+# 33.0.0
 # See https://developer.android.com/studio/releases/platforms
-ARG ANDROID_PLATFORMS_VERSION=33
+ARG ANDROID_PLATFORMS_VERSION=34
 # See https://gradle.org/releases/
-ARG GRADLE_VERSION=8.0.2
+ARG GRADLE_VERSION=8.2.1
 # See https://www.npmjs.com/package/@ionic/cli
 ARG IONIC_VERSION=7.2.0
 # See https://www.npmjs.com/package/@capacitor/cli
-ARG CAPACITOR_VERSION=5.6.0
+ARG CAPACITOR_VERSION=next
+
+ARG USERNAME=vscode
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+ARG HOME=/home/${USERNAME}
+ARG WORKDIR=$HOME
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8
 
 WORKDIR /tmp
 
-RUN apt-get update -q
+SHELL ["/bin/bash", "-l", "-c"] 
 
 # General packages
-RUN apt-get install -qy \
+RUN apt-get update -q && apt-get install -qy \
     apt-utils \
     locales \
     gnupg2 \
     build-essential \
+    ca-certificates \
     curl \
     usbutils \
     git \
@@ -41,6 +54,15 @@ RUN apt-get install -qy \
 
 # Set locale
 RUN locale-gen en_US.UTF-8 && update-locale
+
+# Add user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --create-home --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+# [Optional] Add sudo support for the non-root user
+RUN apt-get install -qy sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
 
 # Install Gradle
 ENV GRADLE_HOME=/opt/gradle
@@ -68,10 +90,22 @@ ENV PATH=$PATH:${HOME}/.npm-global/bin
 RUN npm install -g @ionic/cli@${IONIC_VERSION} \
     && npm install -g @capacitor/cli@${CAPACITOR_VERSION}
 
+# Copy adbkey
+RUN mkdir -p -m 0750 /root/.android
+COPY adbkey/adbkey /root/.android/
+COPY adbkey/adbkey.pub /root/.android/
+
 # Clean up
 RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/*
 
-WORKDIR /workdir
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+WORKDIR $WORKDIR
+
+USER $USERNAME
+
+ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ docker run -it robingenz/ionic-capacitor bash
 ## Questions / Issues
 
 If you got any questions or problems using the image, please visit my [GitHub Repository](https://github.com/robingenz/docker-ionic-capacitor) and write an issue.
+
+### If build fail on mac m1/m2 with qemu x84_64 error add '"runArgs": ["--platform=linux/amd64"]' to devcontainer.json in vscode.


### PR DESCRIPTION
Remove ruby and chrome from image as they don't need for development and build app.

Because capasitor v5 in gradle want to install version 30.0.3 of build tools and in original repo install version 33.0.0 the workaround is to bump capacitor to version 6 with new gradle and build tools.