### PR TITLE
Add main branch in docker build context

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pull from Docker Registry:
 
 Build from GitHub:  
 ```
-docker build -t robingenz/ionic-capacitor github.com/robingenz/docker-ionic-capacitor
+docker build -t robingenz/ionic-capacitor github.com/robingenz/docker-ionic-capacitor#main
 ```
 
 Available build arguments:  


### PR DESCRIPTION
My version of Docker (24.0.5) try to find `master` branch by default. The only existing branch is `main` so precising the build context at the end with `#main` makes it work.